### PR TITLE
allow users to override kafka client conf

### DIFF
--- a/crates/deltaforge-config/src/lib.rs
+++ b/crates/deltaforge-config/src/lib.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::fs;
+use std::{collections::HashMap, fs};
 use thiserror::Error;
 use tracing::error;
 use walkdir::WalkDir;
@@ -118,6 +118,13 @@ pub struct KafkaSinkCfg {
     pub required: Option<bool>,
     #[serde(default)]
     pub exactly_once: Option<bool>,
+
+    /// Raw librdkafka client configuration overrides.
+    ///
+    /// Keys and values are passed directly to `rdkafka::ClientConfig::set`.
+    /// These are applied *after* DeltaForge's own defaults, so user values win.
+    #[serde(default)]
+    pub client_conf: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/sinks/src/kafka.rs
+++ b/crates/sinks/src/kafka.rs
@@ -39,6 +39,11 @@ impl KafkaSink {
                 .set("max.in.flight.requests.per.connection", "5");
         }
 
+        // apply user overrides, if any
+        for (k, v) in &ks_cfg.client_conf {
+            cfg.set(k, v);
+        }
+
         let producer: FutureProducer =
             cfg.create().with_context(|| "creating kafka producer")?;
 


### PR DESCRIPTION
- extends the kafka sink conf to accept an optional "client_conf".
- client_conf items will be applied AFTER the system default (user conf always wins)